### PR TITLE
[2505] there is a fixed text in pricing table

### DIFF
--- a/assets/styles/components/_PricingTable.scss
+++ b/assets/styles/components/_PricingTable.scss
@@ -83,11 +83,9 @@ no-descending-specificity, scss/no-global-function-names */
 
 	.elementor-widget-price-list {
 
-		&.has-note .elementor-price-list-price {
+		.elementor-price-list-price {
 
-			&::after {
-				display: block;
-				content: "(for $3 you get 20 requests)";
+			span.has-note {
 				color: $level-2;
 				margin-top: 0.5em;
 				margin-left: 0.5em;


### PR DESCRIPTION
**Changes proposed in this Pull Request**
The price note in the price tables has been made editable. 
Now you need add after price <span class="has-note">YOUR TEXT<span>

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#2505
