### PR TITLE
[2946] [Bug]: Title tags are doubled

### DIFF
--- a/templates/head.php
+++ b/templates/head.php
@@ -13,7 +13,7 @@
 	<meta name="msapplication-TileColor" content="#da532c" />
 	<meta name="theme-color" content="#ffffff" />
 
-	<?php 
+	<?php
 	function add_inline_styles() {
 		ob_start();
 		$css = file_get_contents( get_template_directory() . '/assets/dist/layouts/Header' . isrtl() . wpenv() . '.css' );
@@ -26,9 +26,8 @@
 	};
 
 	add_inline_styles();
-	wp_head(); 
+	wp_head();
 	?>
-	<?php wp_head(); ?>
 
 	<?php get_template_part( 'lib/pagesources' ); ?>
 </head>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I removed `wp_head()` function because was in the head twice

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#2946
