### PR TITLE
[3135] Hide title "Related articles" if empty 

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -9,3 +9,4 @@
 	require_once get_template_directory() . '/lib/functions/sidebar-toc.php';
 	require_once get_template_directory() . '/lib/functions/widgets.php';
 	require_once get_template_directory() . '/lib/functions/redirects.php';
+	require_once get_template_directory() . '/lib/functions/urlslab-related-posts.php';

--- a/lib/functions/urlslab-related-posts.php
+++ b/lib/functions/urlslab-related-posts.php
@@ -1,0 +1,17 @@
+<?php
+
+function urlslab_display_related_resources() {
+	// do_shortcode for related resources
+	$related_resources = do_shortcode( '[urlslab-related-resources url="' . get_the_permalink() . '" related-count="4" show-image="true" show-summary="true"]' );
+
+	if ( ! empty( $related_resources ) ) :
+		?>
+		<div class="Post__content__resources">
+			<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
+			<div class="SimilarSources">
+				<?= wp_kses_post( $related_resources ); ?>
+			</div>
+		</div>
+		<?php
+	endif;
+}

--- a/template-blog-header.php
+++ b/template-blog-header.php
@@ -38,12 +38,7 @@
 			<div class="Content">
 				<?php the_content(); ?>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/template-blog.php
+++ b/template-blog.php
@@ -85,12 +85,6 @@ set_custom_source( 'custom_lightbox', 'js' );
 	<div class="BlogPost__content Content" itemprop="articleBody">
 		<?php the_content(); ?>
 
-		<div class="Post__content__resources">
-			<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-			<div class="SimilarSources">
-				<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-			</div>
-		</div>
+		<?php urlslab_display_related_resources(); ?>
 	</div>
 </div>

--- a/templates/content-page.php
+++ b/templates/content-page.php
@@ -2,12 +2,16 @@
 the_content();
 
 if ( ! is_page( 'sitemap' ) && ! is_front_page() ) {
-	?>
+
+	$related_resources = do_shortcode( '[urlslab-related-resources url="' . get_the_permalink() . '" related-count="4" show-image="true" show-summary="true"]' );
+
+	if ( ! empty( $related_resources ) ) {
+		?>
 	<div class="SimilarSources SimilarSources--blog">
 		<div class="wrapper">
 			<div class="SimilarSources__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-			<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
+			<?= wp_kses_post( $related_resources ); ?>
 		</div>
 	</div>
+	<?php } ?>
 <?php } ?>

--- a/templates/content-single-features.php
+++ b/templates/content-single-features.php
@@ -50,13 +50,7 @@ if ( $categories && $categories_url ) {
 			<div class="Content" itemprop="articleBody">
 				<?php the_content(); ?>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 		<?php // echo do_shortcode( '[sidebarBanner chatbotType="' . get_post_meta( get_the_ID(), 'chatbot', true ) . '"]' ); ?>

--- a/templates/content-single-glossary.php
+++ b/templates/content-single-glossary.php
@@ -33,13 +33,7 @@ $page_header_args = array(
 					<a href="<?php _e( '/glossary/', 'urlslab' ); ?>" class="Button Button--outline Button--back"><span><?php _e( 'Back to Glossary', 'urlslab' ); ?></span></a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 
 			</div>
 		</div>

--- a/templates/content-single-videos.php
+++ b/templates/content-single-videos.php
@@ -72,13 +72,7 @@ if ( $categories && $categories_url ) {
 					<a href="<?php _e( '/videos/', 'urlslab' ); ?>" class="Button Button--outline Button--back"><span><?php _e( 'Back to Videos', 'urlslab' ); ?></span></a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 
 			</div>
 		</div>

--- a/templates/content-single.php
+++ b/templates/content-single.php
@@ -124,13 +124,7 @@ if ( isset( $categories ) ) {
 					<?php wp_reset_postdata(); ?>
 				</div>
 
-
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I created a function to display related articles via a shortcode from urlslab and added a condition to display the title only if the urlslab shortcode displays something and also added a url parameter to the shortcode. And i replaced old code in the all templates

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3135
